### PR TITLE
Rename some titles for additional clarity

### DIFF
--- a/Help Desk/issues_create.php
+++ b/Help Desk/issues_create.php
@@ -55,7 +55,7 @@ if (!isActionAccessible($guid, $connection2, "/modules/Help Desk/issues_create.p
     $form->addHiddenValue('address', $gibbon->session->get('address'));
     
     $row = $form->addRow();
-        $row->addLabel('issueName', __('Issue Name'));
+        $row->addLabel('issueName', __('Issue Subject'));
         $row->addTextField('issueName')
             ->required()
             ->maxLength(55);

--- a/Help Desk/issues_discussView.php
+++ b/Help Desk/issues_discussView.php
@@ -98,7 +98,7 @@ if (!isModuleAccessible($guid, $connection2)) {
 
             $detailsData = array(
                 'issueID' => $issueID,
-                'owner' => Format::name($owner['title'] , $owner['preferredName'] , $owner['surname'] , 'Student'),
+                'owner' => Format::nameLinked($owner['gibbonPersonID'], $owner['title'] , $owner['preferredName'] , $owner['surname'] , 'Staff'),
                 'technician' => $hasTechAssigned ? Format::name($technician['title'] , $technician['preferredName'] , $technician['surname'] , 'Student') : __('Unassigned'),
                 'date' => Format::date($issue['date']),
                 'privacySetting' => $issue['privacySetting'],

--- a/Help Desk/issues_view.php
+++ b/Help Desk/issues_view.php
@@ -254,7 +254,7 @@ if (!isModuleAccessible($guid, $connection2)) {
 
     $table->addColumn('issueID', __('Issue ID'))
             ->format(Format::using('number', ['issueID'])); 
-    $table->addColumn('issueName', __('Name'))
+    $table->addColumn('issueName', __('Subject'))
           ->description(__('Description'))
           ->format(function ($issue) {
             return '<strong>' . $issue['issueName'] . '</strong><br/><small><i>' . Format::truncate(strip_tags($issue['description']), 50) . '</i></small>';


### PR DESCRIPTION
i.e. name > title, so that staff stop writing their name in the issue name field.